### PR TITLE
Add Android Studio's logcat compatibility for threadtime format

### DIFF
--- a/logcat-threadtime.YAML-tmLanguage
+++ b/logcat-threadtime.YAML-tmLanguage
@@ -12,8 +12,8 @@ firstLineMatch: -* beginning of /dev/log/.*
 # match: '(?x)^
 #       (?:\s*(\d+:)\s*)?         # (optional) line number
 #       ([\d-]+)\s+([\d:.]+)\s+   # date, time
-#       (\d+)\s+(\d+)\s+          # pid, tid
-#       ([VDIWEF])\s+(.*?):\s+    # log type, log tag
+#       (\d+)[-\s]+(\d+)\S*\s+    # pid, tid, package(optional)
+#       ([VDIWEF])[/\s]+(.*?):\s+ # log type, log tag
 #       (.*)                      # log message
 #       $'
 # captures:
@@ -41,8 +41,8 @@ repository:
       match: '(?x)^
             (?:\s*(\d+:)\s*)?
             ([\d-]+)\s+([\d:.]+)\s+
-            (\d+)\s+(\d+)\s+
-            ([V])\s+(.*?):\s+
+            (\d+)[-\s]+(\d+)\S*\s+
+            ([V])[/\s]+(.*?):\s+
             (.*)
             $'
       captures:
@@ -61,8 +61,8 @@ repository:
       match: '(?x)^
             (?:\s*(\d+:)\s*)?
             ([\d-]+)\s+([\d:.]+)\s+
-            (\d+)\s+(\d+)\s+
-            ([D])\s+(.*?):\s+
+            (\d+)[-\s]+(\d+)\S*\s+
+            ([D])[/\s]+(.*?):\s+
             (.*)
             $'
       captures:
@@ -81,8 +81,8 @@ repository:
       match: '(?x)^
             (?:\s*(\d+:)\s*)?
             ([\d-]+)\s+([\d:.]+)\s+
-            (\d+)\s+(\d+)\s+
-            ([I])\s+(.*?):\s+
+            (\d+)[-\s]+(\d+)\S*\s+
+            ([I])[/\s]+(.*?):\s+
             (.*)
             $'
       captures:
@@ -101,8 +101,8 @@ repository:
       match: '(?x)^
             (?:\s*(\d+:)\s*)?
             ([\d-]+)\s+([\d:.]+)\s+
-            (\d+)\s+(\d+)\s+
-            ([W])\s+(.*?):\s+
+            (\d+)[-\s]+(\d+)\S*\s+
+            ([W])[/\s]+(.*?):\s+
             (.*)
             $'
       captures:
@@ -121,8 +121,8 @@ repository:
       match: '(?x)^
             (?:\s*(\d+:)\s*)?
             ([\d-]+)\s+([\d:.]+)\s+
-            (\d+)\s+(\d+)\s+
-            ([EF])\s+(.*?):\s+
+            (\d+)[-\s]+(\d+)\S*\s+
+            ([EF])[/\s]+(.*?):\s+
             (.*)
             $'
       captures:

--- a/logcat-threadtime.tmLanguage
+++ b/logcat-threadtime.tmLanguage
@@ -82,7 +82,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)\s+(\d+)\s+ ([D])\s+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([D])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.debug</string>
 				</dict>
@@ -137,7 +137,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)\s+(\d+)\s+ ([EF])\s+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([EF])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.error</string>
 				</dict>
@@ -192,7 +192,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)\s+(\d+)\s+ ([I])\s+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([I])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.info</string>
 				</dict>
@@ -247,7 +247,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)\s+(\d+)\s+ ([V])\s+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([V])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.verbose</string>
 				</dict>
@@ -302,7 +302,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)\s+(\d+)\s+ ([W])\s+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([W])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.warn</string>
 				</dict>

--- a/logcat-threadtime.tmLanguage
+++ b/logcat-threadtime.tmLanguage
@@ -82,7 +82,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([D])[/\s]+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)[\S\s]*\s+ ([D])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.debug</string>
 				</dict>
@@ -137,7 +137,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([EF])[/\s]+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)[\S\s]*\s+ ([EF])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.error</string>
 				</dict>
@@ -192,7 +192,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([I])[/\s]+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)[\S\s]*\s+ ([I])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.info</string>
 				</dict>
@@ -247,7 +247,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([V])[/\s]+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)[\S\s]*\s+ ([V])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.verbose</string>
 				</dict>
@@ -302,7 +302,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)\S*\s+ ([W])[/\s]+(.*?):\s+ (.*) $</string>
+					<string>(?x)^ (?:\s*(\d+:)\s*)? ([\d-]+)\s+([\d:.]+)\s+ (\d+)[-\s]+(\d+)[\S\s]*\s+ ([W])[/\s]+(.*?):\s+ (.*) $</string>
 					<key>name</key>
 					<string>meta.logcat.line.warn</string>
 				</dict>


### PR DESCRIPTION
Fix Android Studio's logcat compatibility issue: #3 

Main change:
before: `(\d+)\s+(\d+)\s+`  after: `(\d+)[-\s]+(\d+)\S*\s+`  for `pid, tid`
before: `([VDIWEF])\s+(.*?):\s+`  after: `([VDIWEF])[/\s]+(.*?):\s+`  for `log type, log tag`

And regenerate `.tmLanguage` file by `PackageDev` plugin